### PR TITLE
DATA-285: fix bug where ULPC would throw a NPE when at least one line publishedName is null

### DIFF
--- a/mobi.chouette.dao/src/main/java/mobi/chouette/dao/LineDAOImpl.java
+++ b/mobi.chouette.dao/src/main/java/mobi/chouette/dao/LineDAOImpl.java
@@ -70,6 +70,17 @@ public class LineDAOImpl extends GenericDAOImpl<Line> implements LineDAO {
 	}
 
 	@Override
+	public List<Line> findByNetworkIdNotDeleted(Long networkId) {
+		return em.createQuery("SELECT l " +
+						"              FROM Line l " +
+						"              INNER JOIN l.network n" +
+						"              ON n.id = :networkId" +
+						"              WHERE l.supprime = false", Line.class)
+				.setParameter("networkId", networkId)
+				.getResultList();
+	}
+
+	@Override
 	public List<Line> findNotDeleted() {
 		return em.createQuery("SELECT l " +
 						"              FROM Line l " +

--- a/mobi.chouette.exchange/pom.xml
+++ b/mobi.chouette.exchange/pom.xml
@@ -172,6 +172,11 @@
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <!--  <build>
         <plugins>

--- a/mobi.chouette.exchange/src/test/java/mobi/chouette/exchange/importer/UpdateLinePositionCommandTest.java
+++ b/mobi.chouette.exchange/src/test/java/mobi/chouette/exchange/importer/UpdateLinePositionCommandTest.java
@@ -36,7 +36,7 @@ public class UpdateLinePositionCommandTest {
     }
 
     @Test(dataProvider = "nullAndEmptyNetworks")
-    public void test_execute__when_no_networks__updates_no_position(List<Network> networks) throws Exception {
+    public void testExecute_whenNoNetworks_updatesNoPosition(List<Network> networks) throws Exception {
         // arrange
         Mockito.when(networkDAOMock.findAll()).thenReturn(networks);
 
@@ -56,7 +56,7 @@ public class UpdateLinePositionCommandTest {
     }
 
     @Test(dataProvider = "nullAndEmptyLines")
-    public void test_execute__when_no_lines_on_networks__updates_no_position(List<Line> lines) throws Exception {
+    public void testExecute_whenNoLinesOnNetworks__updatesNoPosition(List<Line> lines) throws Exception {
         // arrange
         Network network = new Network();
         network.setId(1L);
@@ -75,7 +75,7 @@ public class UpdateLinePositionCommandTest {
     }
 
     @Test
-    void test_execute__when_positions_are_updated__updates_them_correctly() throws Exception {
+    void testExecute_whenPositionsAreUpdated__updatesThemCorrectly() throws Exception {
         // arrange
         Network n1 = new Network();
         n1.setId(1L);
@@ -143,7 +143,7 @@ public class UpdateLinePositionCommandTest {
     }
 
     @Test
-    void test_execute__when_at_least_one_line_has_no_position_and_no_published_name__do_not_throws_NPE() throws Exception {
+    void testExecute_whenAtLeastOneLineHasNoPositionAndNoPublishedName_doNotThrowNPE() throws Exception {
         // arrange
         Network network = new Network();
         network.setId(1L);
@@ -210,7 +210,7 @@ public class UpdateLinePositionCommandTest {
     }
 
     @Test
-    void test_execute__when_no_line_position_is_updated__do_not_flush() throws Exception {
+    void testExecute_whenNoLinePositionIsUpdated_doNotFlush() throws Exception {
         // arrange
         Network network = new Network();
         network.setId(1L);

--- a/mobi.chouette.exchange/src/test/java/mobi/chouette/exchange/importer/UpdateLinePositionCommandTest.java
+++ b/mobi.chouette.exchange/src/test/java/mobi/chouette/exchange/importer/UpdateLinePositionCommandTest.java
@@ -1,0 +1,252 @@
+package mobi.chouette.exchange.importer;
+
+
+import mobi.chouette.common.Context;
+import mobi.chouette.dao.LineDAO;
+import mobi.chouette.dao.NetworkDAO;
+import mobi.chouette.model.Line;
+import mobi.chouette.model.Network;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class UpdateLinePositionCommandTest {
+
+    private LineDAO lineDAOMock;
+    private NetworkDAO networkDAOMock;
+    UpdateLinePositionCommand tested;
+
+    @BeforeMethod
+    private void beforeMethod() {
+        lineDAOMock = Mockito.mock(LineDAO.class);
+        networkDAOMock = Mockito.mock(NetworkDAO.class);
+        tested = new UpdateLinePositionCommand(lineDAOMock, networkDAOMock);
+    }
+
+    @DataProvider(name="nullAndEmptyNetworks")
+    private Object[][] nullAndEmptyNetworks() {
+        return new Object[][]{ { null }, { new ArrayList<Network>() } };
+    }
+
+    @Test(dataProvider = "nullAndEmptyNetworks")
+    public void test_execute__when_no_networks__updates_no_position(List<Network> networks) throws Exception {
+        // arrange
+        Mockito.when(networkDAOMock.findAll()).thenReturn(networks);
+
+        // act
+        boolean out = tested.execute(new Context());
+
+        // assert
+        Assert.assertTrue(out, "should return true");
+        Mockito.verify(lineDAOMock, Mockito.never()).update(Mockito.any());
+        Mockito.verify(lineDAOMock, Mockito.never()).flush();
+
+    }
+
+    @DataProvider(name="nullAndEmptyLines")
+    private Object[][] nullAndEmptyLines() {
+        return new Object[][]{ { null }, { new ArrayList<Line>() } };
+    }
+
+    @Test(dataProvider = "nullAndEmptyLines")
+    public void test_execute__when_no_lines_on_networks__updates_no_position(List<Line> lines) throws Exception {
+        // arrange
+        Network network = new Network();
+        network.setId(1L);
+        network.setSupprime(false);
+
+        Mockito.when(networkDAOMock.findAll()).thenReturn(Collections.singletonList(network));
+        Mockito.when(lineDAOMock.findByNetworkIdNotDeleted(network.getId())).thenReturn(lines);
+
+        // act
+        boolean out = tested.execute(new Context());
+
+        // assert
+        Assert.assertTrue(out, "should return true");
+        Mockito.verify(lineDAOMock, Mockito.never()).update(Mockito.any());
+        Mockito.verify(lineDAOMock, Mockito.never()).flush();
+    }
+
+    @Test
+    void test_execute__when_positions_are_updated__updates_them_correctly() throws Exception {
+        // arrange
+        Network n1 = new Network();
+        n1.setId(1L);
+        n1.setSupprime(false);
+
+        Network n2 = new Network();
+        n2.setId(2L);
+        n2.setSupprime(false);
+
+        Line l1 = new Line();
+        l1.setId(1L);
+        l1.setSupprime(false);
+        l1.setPublishedName("l1");
+        l1.setPosition(null);
+
+        Line l2 = new Line();
+        l2.setId(2L);
+        l2.setSupprime(false);
+        l2.setPublishedName("l2");
+        l2.setPosition(5);
+
+        Line l3 = new Line();
+        l3.setId(3L);
+        l3.setSupprime(false);
+        l3.setPublishedName("l3");
+        l3.setPosition(1);
+
+        Line l4 = new Line();
+        l4.setId(4L);
+        l4.setSupprime(false);
+        l4.setPublishedName("l4");
+        l4.setPosition(5);
+
+        Line l5 = new Line();
+        l5.setId(5L);
+        l5.setSupprime(false);
+        l5.setPublishedName("l5");
+        l5.setPosition(1500);
+
+        Line l6 = new Line();
+        l6.setId(6L);
+        l6.setSupprime(false);
+        l6.setPublishedName("l6");
+        l6.setPosition(null);
+
+        Mockito.when(networkDAOMock.findAll()).thenReturn(Arrays.asList(n1, n2));
+        Mockito.when(lineDAOMock.findByNetworkIdNotDeleted(n1.getId())).thenReturn(Arrays.asList(l1, l2, l3));
+        Mockito.when(lineDAOMock.findByNetworkIdNotDeleted(n2.getId())).thenReturn(Arrays.asList(l4, l5, l6));
+
+        // act
+        boolean out = tested.execute(new Context());
+
+        // assert
+        Assert.assertTrue(out, "should return true");
+        Assert.assertEquals(l1.getPosition().intValue(), 3, "position should be equal");
+        Assert.assertEquals(l2.getPosition().intValue(), 2, "position should be equal");
+        Assert.assertEquals(l3.getPosition().intValue(), 1, "position should be equal");
+
+        Assert.assertEquals(l4.getPosition().intValue(), 1, "position should be equal");
+        Assert.assertEquals(l5.getPosition().intValue(), 2, "position should be equal");
+        Assert.assertEquals(l6.getPosition().intValue(), 3, "position should be equal");
+
+        Mockito.verify(lineDAOMock, Mockito.times(5)).update(Mockito.any());
+        Mockito.verify(lineDAOMock).flush();
+    }
+
+    @Test
+    void test_execute__when_at_least_one_line_has_no_position_and_no_published_name__do_not_throws_NPE() throws Exception {
+        // arrange
+        Network network = new Network();
+        network.setId(1L);
+        network.setSupprime(false);
+
+        Line l1 = new Line();
+        l1.setId(1L);
+        l1.setSupprime(false);
+        l1.setPublishedName(null);
+        l1.setPosition(null);
+
+        Line l2 = new Line();
+        l2.setId(2L);
+        l2.setSupprime(false);
+        l2.setPublishedName("l2");
+        l2.setPosition(5);
+
+        Line l3 = new Line();
+        l3.setId(3L);
+        l3.setSupprime(false);
+        l3.setPublishedName("l3");
+        l3.setPosition(1);
+
+        Line l4 = new Line();
+        l4.setId(4L);
+        l4.setSupprime(false);
+        l4.setPublishedName("l4");
+        l4.setPosition(5);
+
+        Line l5 = new Line();
+        l5.setId(5L);
+        l5.setSupprime(false);
+        l5.setPublishedName("l5");
+        l5.setPosition(1500);
+
+        Line l6 = new Line();
+        l6.setId(6L);
+        l6.setSupprime(false);
+        l6.setPublishedName("l6");
+        l6.setPosition(null);
+
+        Mockito.when(networkDAOMock.findAll()).thenReturn(Collections.singletonList(network));
+        Mockito.when(lineDAOMock.findByNetworkIdNotDeleted(network.getId())).thenReturn(Arrays.asList(l1, l2, l3, l4, l5, l6));
+
+        try {
+            // act
+            boolean out = tested.execute(new Context());
+
+            // assert
+            Assert.assertTrue(out, "should return true");
+        } catch (NullPointerException e) {
+            Assert.fail("should not raise NullPointerException");
+        }
+
+        Assert.assertEquals(l1.getPosition().intValue(), 6, "position should be equal");
+        Assert.assertEquals(l2.getPosition().intValue(), 2, "position should be equal");
+        Assert.assertEquals(l3.getPosition().intValue(), 1, "position should be equal");
+        Assert.assertEquals(l4.getPosition().intValue(), 3, "position should be equal");
+        Assert.assertEquals(l5.getPosition().intValue(), 4, "position should be equal");
+        Assert.assertEquals(l6.getPosition().intValue(), 5, "position should be equal");
+
+        Mockito.verify(lineDAOMock, Mockito.times(5)).update(Mockito.any());
+        Mockito.verify(lineDAOMock).flush();
+    }
+
+    @Test
+    void test_execute__when_no_line_position_is_updated__do_not_flush() throws Exception {
+        // arrange
+        Network network = new Network();
+        network.setId(1L);
+        network.setSupprime(false);
+
+        Line l1 = new Line();
+        l1.setId(1L);
+        l1.setPosition(1);
+        l1.setSupprime(false);
+        l1.setPublishedName("l1");
+
+        Line l2 = new Line();
+        l2.setId(2L);
+        l2.setPosition(2);
+        l2.setSupprime(false);
+        l2.setPublishedName("l2");
+
+        Line l3 = new Line();
+        l3.setId(3L);
+        l3.setPosition(3);
+        l3.setSupprime(false);
+        l3.setPublishedName("l3");
+
+        Mockito.when(networkDAOMock.findAll()).thenReturn(Collections.singletonList(network));
+        Mockito.when(lineDAOMock.findByNetworkIdNotDeleted(network.getId())).thenReturn(Arrays.asList(l1, l2, l3));
+
+        // act
+        boolean out = tested.execute(new Context());
+
+        // assert
+        Assert.assertTrue(out, "should return true");
+
+        Mockito.verify(lineDAOMock, Mockito.never()).update(Mockito.any());
+        Mockito.verify(lineDAOMock, Mockito.never()).flush();
+    }
+
+}
+
+

--- a/mobi.chouette.model/src/main/java/mobi/chouette/dao/LineDAO.java
+++ b/mobi.chouette.model/src/main/java/mobi/chouette/dao/LineDAO.java
@@ -14,6 +14,8 @@ public interface LineDAO extends GenericDAO<Line> {
 
     List<Line> findByNetworkId(Long networkId);
 
+    List<Line> findByNetworkIdNotDeleted(Long networkId);
+
     List<Line> findNotDeleted();
 
     List<String> findObjectIdLinesInFirstDataspace(List<Long> ids, String dataspace);


### PR DESCRIPTION
- Added fix to avoid NPE
- Added unit test for ULPC
- Refactor ULPC to retrieve only activated line from DB (used to query all lines from DB then filter activated @ chouette)
- Add mockito deps to mobi.chouette.exchange